### PR TITLE
fix(delete training and event): fixed issue where training and events could not be deleted

### DIFF
--- a/src/actions/event.ts
+++ b/src/actions/event.ts
@@ -266,6 +266,10 @@ export async function deleteEvent(id: number) {
   logger.info('Deleting event', { eventId: id }, 'deleteEvent')
 
   try {
+    // First, delete all event assignments for this event
+    await db.delete(eventAssignments).where(eq(eventAssignments.event_id, id))
+
+    // Then delete the event itself
     const [deletedEvent] = await db
       .delete(events)
       .where(eq(events.id, id))

--- a/src/actions/training.ts
+++ b/src/actions/training.ts
@@ -3,7 +3,7 @@
 import type { RequiredTrainingFields, UpdateTraining } from '@/types/training'
 import { toISOString } from '@/lib/utils'
 import { db } from '@/libs/DB'
-import { training } from '@/models/Schema'
+import { training, trainingAssignments } from '@/models/Schema'
 import { eq } from 'drizzle-orm'
 import { createLogger } from '@/lib/debug'
 import { createClient } from '@/lib/server'
@@ -348,6 +348,12 @@ export async function deleteTraining(id: number) {
       return null
     }
 
+    // First, delete all training assignments for this training
+    await db
+      .delete(trainingAssignments)
+      .where(eq(trainingAssignments.training_id, id))
+
+    // Then delete the training itself
     const [deletedTraining] = await db
       .delete(training)
       .where(eq(training.id, id))

--- a/src/app/(auth)/admin/training/columns.tsx
+++ b/src/app/(auth)/admin/training/columns.tsx
@@ -50,7 +50,6 @@ function TrainingActions({
       const result = await deleteTraining(training.id)
       if (result) {
         toast.success('Training deleted successfully')
-        router.refresh()
       } else {
         toast.error('Failed to delete training')
       }
@@ -61,6 +60,8 @@ function TrainingActions({
         'columns'
       )
       toast.error('Failed to delete training')
+    } finally {
+      router.refresh()
     }
   }
 


### PR DESCRIPTION
When an admin tried to delete a training or event, a FK constraint error was thrown because of existing training/event assignments. This fix deletes the training/event assignments prior to deleting the training/event.